### PR TITLE
change mysql to mysqli

### DIFF
--- a/ADfine.php
+++ b/ADfine.php
@@ -21,13 +21,7 @@
 				<br><br><br>
 
 <?php
- $server = "localhost"; 
-	$user = "root";
-	$password = "";
-	$database = "library"; 
-	mysql_connect($server,$user,$password)
-	or die ("Connection Fails"); 
-	mysql_select_db($database) or die ("Database Not Found");
+ include 'conn.php';
 echo "<table border='1' align='center' cellpadding='5'> 
  <th>Issue_id </th>
  <th>Return_id </th>
@@ -40,11 +34,11 @@ echo "<table border='1' align='center' cellpadding='5'>
  <th>Amount</th>
  <th>Action</th>";
 
-$result=mysql_query("SELECT * FROM returnstore where diff>0");
+$result=$mysqli->query("SELECT * FROM returnstore where diff>0");
 
 $no=1;
 	
-	while ($row=mysql_fetch_array($result))
+	while ($row=$result->fetch_array())
 	{
     $return_id=$row['Return_id'];
 	$issue_id=$row['Issue_id'];

--- a/ADissue.php
+++ b/ADissue.php
@@ -1,11 +1,10 @@
 
 <?php
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 	
 	$request_id=$_GET['request_id'];
-	$result=mysql_query("SELECT * FROM requestbook where Request_id=$request_id");
-	$row = mysql_fetch_array($result);
+	$result=$mysqli->query("SELECT * FROM requestbook where Request_id=$request_id");
+	$row = $result->fetch_array();
 	$request_id=$row['Request_id'];
     $mid=$row['Mid'];
 	$name=$row['Name'];
@@ -13,15 +12,15 @@
 	$bname=$row['Bname'];
 	
 	//insert request record into issue table
-	$sql=mysql_query("INSERT INTO issuebook(Request_id,Mid,Name,Bid,Bname,Issue_date,validreturndate)
+	$sql=$mysqli->query("INSERT INTO issuebook(Request_id,Mid,Name,Bid,Bname,Issue_date,validreturndate)
 	   VALUES('$request_id','$mid','$name','$bid','$bname',now(),ADDDATE(now(),8))");
      
-	$result=mysql_query($sql);
+	$result=$mysqli->query($sql);
 	
-	$sql4=mysql_query("update book set Availability='no' where Bid='$bid'");
+	$sql4=$mysqli->query("update book set Availability='no' where Bid='$bid'");
 	
-	$query=mysql_query("select * from member where Mid='$mid'");
-	while ($r=mysql_fetch_array($query))
+	$query=$mysqli->query("select * from member where Mid='$mid'");
+	while ($r=$query->fetch_array())
 	{
 		$book1=$r['Book1'];
 	
@@ -31,26 +30,26 @@
 	
 	if($book1==NULL)
 	{
-		$sql2=mysql_query("update member set Book1='$bid' where Mid='$mid'");
+		$sql2=$mysqli->query("update member set Book1='$bid' where Mid='$mid'");
 	}
 	else
 	{
-		$sql3=mysql_query("update member set Book2='$bid' where Mid='$mid'");
+		$sql3=$mysqli->query("update member set Book2='$bid' where Mid='$mid'");
 	}
 	
 	
 	
 	//insert issue record into issuestore
-	$sql=mysql_query("select * from issuebook where Request_id='$request_id'");
+	$sql=$mysqli->query("select * from issuebook where Request_id='$request_id'");
 	
-	while ($row=mysql_fetch_array($sql))
+	while ($row=$sql->fetch_array())
 	{
 	$Issue_id=$row['Issue_id'];
     $mid=$row['Mid'];
 	$name=$row['Name'];
 	$bid=$row['Bid'];
 	$bname=$row['Bname'];
-	$sql=mysql_query("INSERT INTO issuestore(Issue_id,Mid,Name,Bid,Bname,Issue_date,validreturndate)
+	$sql=$mysqli->query("INSERT INTO issuestore(Issue_id,Mid,Name,Bid,Bname,Issue_date,validreturndate)
 	   VALUES('$Issue_id','$mid','$name','$bid','$bname',now(),ADDDATE(now(),8))");
 	}
 	
@@ -58,8 +57,8 @@
 	
 	
 	//delete request record
-	$sql1=mysql_query("DELETE FROM requestbook WHERE Request_id='$request_id'"); 
-    $result1=mysql_query($sql1);
+	$sql1=$mysqli->query("DELETE FROM requestbook WHERE Request_id='$request_id'"); 
+    $result1=$mysqli->query($sql1);
 header ('location:admin.php');
 
 

--- a/ADissueview_book.php
+++ b/ADissueview_book.php
@@ -19,26 +19,20 @@
 				<!-- Column 1 start -->
 				<br><br><br>
 <?php 
-	$server = "localhost"; 
-	$user = "root";
-	$password = "";
-	$database = "library"; 
-	mysql_connect($server,$user,$password)
-	or die ("Connection Fails"); 
-	mysql_select_db($database) or die ("Database Not Found");
+	include 'conn.php';
   
 	//check for request expiry  
 	
-	$data = mysql_query("SELECT * FROM requestbook");
+	$data = $mysqli->query("SELECT * FROM requestbook");
 	
-	while ($r=mysql_fetch_array($data))
+	while ($r=$data->fetch_array())
 	{
 		$requestdate=new DateTime($r['requestdate']);
 		$viewrequestdate=new DateTime(date('Y-m-d'));
 		$diff=date_diff($requestdate,$viewrequestdate);
 		$days=$diff->d;
-		$sql=mysql_query("Update requestbook set requestexpirydays='$days'");
-		$sql1=mysql_query("delete from requestbook where requestexpirydays>0");
+		$sql=$mysqli->query("Update requestbook set requestexpirydays='$days'");
+		$sql1=$mysqli->query("delete from requestbook where requestexpirydays>0");
 	}
 	
  

--- a/ADmember_edit.php
+++ b/ADmember_edit.php
@@ -20,17 +20,10 @@
 				<!-- Column 1 start -->
 				<br>
 				<?php
- $server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
+ include 'conn.php';
  
- 
- $data = mysql_query("SELECT * FROM member WHERE Mid='$_GET[mid]'");
- $r=mysql_fetch_array($data);
+ $data = $mysqli->query("SELECT * FROM member WHERE Mid='$_GET[mid]'");
+ $r=$data->fetch_array();
   
  echo "<h2>Edit Account</h2><hr> 
  <form method='POST' action='ADupdate_member.php'> 

--- a/ADreturn.php
+++ b/ADreturn.php
@@ -1,14 +1,13 @@
 
 <?php
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 	
 	$claim_return_id=$_GET['claim_return_id'];
-	$result=mysql_query("SELECT * FROM claimreturn where claim_return_id='$claim_return_id'");
+	$result=$mysqli->query("SELECT * FROM claimreturn where claim_return_id='$claim_return_id'");
 	
 	
 	
-	while ($row=mysql_fetch_array($result))
+	while ($row=$result->fetch_array())
 	{
 	$issue_id=$row['Issue_id'];
 	$mid=$row['Mid'];
@@ -21,25 +20,25 @@
 		$diff=date_diff($returndate,$validreturndate1);
 		$days=$diff->d;
 	//insert requestclaim record into return table
-	$sql=mysql_query("INSERT INTO returnbook(Issue_id,claim_return_id,Mid,Name,Bid,Bname,validreturndate,Return_date,diff)
+	$sql=$mysqli->query("INSERT INTO returnbook(Issue_id,claim_return_id,Mid,Name,Bid,Bname,validreturndate,Return_date,diff)
 	   VALUES('$issue_id','$claim_return_id','$mid','$name','$bid','$bname','$validreturndate',now(),'$days')");
      
-	$result=mysql_query($sql);
+	$result=$mysqli->query($sql);
 	
      }
 	 
 	
 	
-	$sql2=mysql_query("update member set Book1=NULL where Mid='$mid'");
+	$sql2=$mysqli->query("update member set Book1=NULL where Mid='$mid'");
 	
-	$sql3=mysql_query("DELETE FROM claimreturn WHERE claim_return_id='$claim_return_id'"); 
+	$sql3=$mysqli->query("DELETE FROM claimreturn WHERE claim_return_id='$claim_return_id'"); 
 	
-	$sql4=mysql_query("update book set Availability='yes' where Bid='$bid'");
+	$sql4=$mysqli->query("update book set Availability='yes' where Bid='$bid'");
 //inser into return store
 
 
-$result=mysql_query("SELECT * FROM returnbook where claim_return_id='$claim_return_id'");
-	while ($row=mysql_fetch_array($result))
+$result=$mysqli->query("SELECT * FROM returnbook where claim_return_id='$claim_return_id'");
+	while ($row=$result->fetch_array())
 	{
     $return_id=$row['Return_id'];
 	$issue_id=$row['Issue_id'];
@@ -50,23 +49,23 @@ $result=mysql_query("SELECT * FROM returnbook where claim_return_id='$claim_retu
 	$validreturndate=$row['validreturndate'];
     $returndate=$row['Return_date'];
 	
-	$sql=mysql_query("INSERT INTO returnstore(Return_id,Issue_id,Bid,Bname,Mid,Name,validreturndate,Return_date,diff)
+	$sql=$mysqli->query("INSERT INTO returnstore(Return_id,Issue_id,Bid,Bname,Mid,Name,validreturndate,Return_date,diff)
 	   VALUES('$return_id','$issue_id','$bid','$bname','$mid','$name','$validreturndate',now(),'$days')");
      
-	$result=mysql_query($sql);
+	$result=$mysqli->_query($sql);
 	
      }
 
 
 //delete returnclaim record	 and return record
-$sql1=mysql_query("DELETE FROM claimreturn WHERE claim_return_id='$claim_return_id'"); 
-    $result1=mysql_query($sql1);
+$sql1=$mysqli->query("DELETE FROM claimreturn WHERE claim_return_id='$claim_return_id'"); 
+    $result1=$mysqli->query($sql1);
 
-$sql1=mysql_query("DELETE FROM returnbook WHERE claim_return_id='$claim_return_id'"); 
-    $result1=mysql_query($sql1);
+$sql1=$mysqli->query("DELETE FROM returnbook WHERE claim_return_id='$claim_return_id'"); 
+    $result1$mysqli->query($sql1);
 
-$sql1=mysql_query("DELETE FROM issuebook WHERE Issue_id='$issue_id'"); 
-    $result1=mysql_query($sql1);
+$sql1=$mysqli->query("DELETE FROM issuebook WHERE Issue_id='$issue_id'"); 
+    $result1=$mysqli->query($sql1);
 	
 	//create fine record
 

--- a/ADreturn_view.php
+++ b/ADreturn_view.php
@@ -21,14 +21,8 @@
 				<!-- Column 1 start -->
 				<br><br><br>
 				<?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
- $data = mysql_query("SELECT * FROM claimreturn"); 
+include 'conn.php';
+ $data = $mysqli->query("SELECT * FROM claimreturn"); 
    echo "<table border='1' align='center'> 
   <th>Return claimID</th>
   <th>Issue Id</th>
@@ -42,7 +36,7 @@ $user = "root";
  <th>Action</th>";
  
  $no=1;
- while ($r=mysql_fetch_array($data))
+ while ($r=$data->fetch_array())
  { 
  echo "<tr>
  <td>$r[claim_return_id]</td> 

--- a/ADupdate_member.php
+++ b/ADupdate_member.php
@@ -1,13 +1,6 @@
 <?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
-
- mysql_select_db($database) or die ("Database Not Found");  
-$query=mysql_query("UPDATE member SET Name = '$_POST[Name]', Email = '$_POST[Email]', Password = '$_POST[Password]', Branch = '$_POST[Branch]', Year = '$_POST[Year]', ContactNo = '$_POST[ContactNo]', Address = '$_POST[Address]' WHERE Mid = '$_POST[mid]'"); 
+include 'conn.php';
+$query=$mysqli->query("UPDATE member SET Name = '$_POST[Name]', Email = '$_POST[Email]', Password = '$_POST[Password]', Branch = '$_POST[Branch]', Year = '$_POST[Year]', ContactNo = '$_POST[ContactNo]', Address = '$_POST[Address]' WHERE Mid = '$_POST[mid]'"); 
 
 
 header ('location:ADview_member.php'); 

--- a/ADview_book.php
+++ b/ADview_book.php
@@ -20,14 +20,9 @@
 				<!-- Column 1 start -->
 				<br><br><br>
 				<?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
- $data = mysql_query("SELECT * FROM book"); 
+include 'conn.php';
+
+ $data = $mysqli->query("SELECT * FROM book"); 
    echo "<table border='1' align='center' cellpadding='5'> 
  <th>Book ID</th> 
  <th>Book Name</th> 
@@ -40,7 +35,7 @@ $user = "root";
  <th>Acction</th>";
  
  
- while ($r=mysql_fetch_array($data))
+ while ($r=$data->fetch_array())
  { 
  echo "<tr>
  <td>$r[Bid]</td> 

--- a/ADview_member.php
+++ b/ADview_member.php
@@ -21,14 +21,8 @@
 				<br>
 				<h2>Member Details</h2>
 				<?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
- $data = mysql_query("SELECT * FROM member"); 
+include 'conn.php';
+ $data = $mysqli->query("SELECT * FROM member"); 
  echo "<table border='1'> 
  <th>Name</th> 
  <th>Roll No:</th> 
@@ -43,7 +37,7 @@ $user = "root";
  <th>Acction</th>";
  
  
- while ($r=mysql_fetch_array($data))
+ while ($r=$data->fetch_array())
  { 
  echo "<tr>
  <td>$r[Name]</td> 

--- a/add_books.php
+++ b/add_books.php
@@ -78,16 +78,15 @@ if(!empty($_POST['bname']) && !empty($_POST['bid']) )
 	$bid=$_POST['bid'];
 	
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 
-	$query=mysql_query("SELECT * FROM book WHERE Bid='".$bid."'");
-	$numrows=mysql_num_rows($query);
+	$query=$mysqli->query("SELECT * FROM book WHERE Bid='".$bid."'");
+	$numrows=$query->num_rows;
 		if($numrows==0)
 		{
 			$sql="INSERT INTO book(Bid,Bname,Subject,Author,Availability) VALUES('$bid','$bname','$subject','$author','$availability')";
 
-			$result=mysql_query($sql);
+			$result=$mysqli->query($sql);
 
 
 			if($result){

--- a/add_member.php
+++ b/add_member.php
@@ -93,16 +93,15 @@ if(!empty($_POST['name']) && !empty($_POST['pass']) && !empty($_POST['mid']) && 
 	$address=$_POST['address'];
 	
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 
-	$query=mysql_query("SELECT * FROM member WHERE Mid='".$mid."'");
-	$numrows=mysql_num_rows($query);
+	$query=$mysqli->query("SELECT * FROM member WHERE Mid='".$mid."'");
+	$numrows=$query->num_rows;
 	if($numrows==0)
 	{
 	$sql="INSERT INTO member(Name,Mid,Email,Password,Branch,Year,ContactNo,Address) VALUES('$name','$mid','$email','$pass','$branch','$year','$contact','$address')";
 
-	$result=mysql_query($sql);
+	$result=$mysqli->query($sql);
 
 
 	} 

--- a/admin_login.php
+++ b/admin_login.php
@@ -52,35 +52,57 @@ if(!empty($_POST['adusername']) && !empty($_POST['adpassword'])) {
 	$user=$_POST['adusername'];
 	$pass=$_POST['adpassword'];
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
+	$sql = sprintf("SELECT * FROM admin WHERE Email='%s' AND Password='%s'",
+		$mysqli->real_escape_string($user),
+		$mysqli->real_escape_string($pass));
+	
+	$result=$mysqli->query($sql);
+	
+	
+	/* if there are some errors with the sql */
+	if(!$result){
+		$message = 'Invalid query:'.$mysqli->error."<br>";
+		$message .= 'Whole query:'.$sql;
+		die($message);
+	}
 
-	$query=mysql_query("SELECT * FROM admin WHERE Email='".$user."' AND Password='".$pass."'");
-	$numrows=mysql_num_rows($query);
+	//$numrows=mysql_num_rows($query);
+	$numrows = $result->num_rows;
+	
+		
 	if($numrows!=0)
 	{
-	while($row=mysql_fetch_assoc($query))
-	{
-	$dbusername=$row['Email'];
-	$dbpassword=$row['Password'];
-	$Name=$row['Name'];
-	}
+		while($row=$result->fetch_assoc())
+		{
 
-	if($user == $dbusername && $pass == $dbpassword)
-	{
-	session_start();
-	$_SESSION['sess_user']=$Name;
+			$dbusername=$row['Email'];
+			$dbpassword=$row['Password'];
+			$Name=$row['Name'];
+		}
 
-	/* Redirect browser */
-	header("Location: admin.php");
-	}
-	} else {
-	echo "Invalid username or password!";
-	}
 
-} else {
+		if($user == $dbusername && $pass == $dbpassword)
+		{
+
+			session_start();
+			$_SESSION['sess_user']=$Name;
+
+			/* Redirect browser */
+			header("Location: admin.php");
+		}
+	}
+	else{
+		echo "Invalid username or password!";
+	}
+	$result->free();
+	$mysqli->close();
+
+} 
+else {
 	echo "All fields are required!";
 }
+
 }
 ?>
 

--- a/admin_reg.php
+++ b/admin_reg.php
@@ -77,16 +77,14 @@ if(!empty($_POST['name']) && !empty($_POST['pass']) ) {
 	$address=$_POST['add'];
 	
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
-
-	$query=mysql_query("SELECT * FROM admin WHERE Email='".$email."'");
-	$numrows=mysql_num_rows($query);
+	include 'conn.php';
+	$query=$mysqli->query("SELECT * FROM admin WHERE Email='".$email."'");
+	$numrows=$mysqli->num_rows;
 	if($numrows==0)
 	{
 	$sql="INSERT INTO admin(Name,Email,Password,contactno,Address) VALUES('$name','$email','$pass','$contact','$address')";
 
-	$result=mysql_query($sql);
+	$result=$mysqli->query($sql);
 
 
 	if($result){

--- a/book_edit.php
+++ b/book_edit.php
@@ -20,17 +20,10 @@
 				<!-- Column 1 start -->
 				
 				<?php
- $server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
+ include 'conn.php';
  
- 
- $data = mysql_query("SELECT * FROM book WHERE Bid='$_GET[bid]'");
- $r=mysql_fetch_array($data);
+ $data = $mysqli->query("SELECT * FROM book WHERE Bid='$_GET[bid]'");
+ $r=$data->fetch_array();
  
  echo "<h2>Edit Book</h2><hr> 
  <form method='POST' action='update_book.php'> 

--- a/check.php
+++ b/check.php
@@ -29,11 +29,10 @@
 					if(isset($_POST["submit"]))
 					{
 						$code=$_POST['code'];
-						$con=mysql_connect('localhost','root','') or die(mysql_error());
-						mysql_select_db('library') or die("cannot select DB");
+						include 'conn.php';
 						
-						$query=mysql_query("SELECT * FROM library_code");
-						while($row=mysql_fetch_assoc($query))
+						$query=$mysqli->query("SELECT * FROM library_code");
+						while($row=$query->fetch_assoc())
 						{
 							$dbcode=$row['code'];
 						}

--- a/conn.php
+++ b/conn.php
@@ -1,0 +1,11 @@
+<?php
+	// $con=mysql_connect('localhost','root','37890fhasd') or die(mysql_error());
+	// mysql_select_db('library') or die("cannot select DB");
+	$mysqli = new mysqli('localhost','root','37890fhasd','library');
+	if($mysqli->connect_error)
+	{
+		die('Connection Error('.$mysqli->connect_errno.')'.$mysqli->connection_error);
+	}
+
+
+?>

--- a/delete_book.php
+++ b/delete_book.php
@@ -1,11 +1,5 @@
 <?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found"); 
-mysql_query("DELETE FROM book WHERE Bid='$_GET[bid]'"); 
+include 'conn.php';
+$mysqli->query("DELETE FROM book WHERE Bid='$_GET[bid]'"); 
 header ('location:ADview_book.php'); 
 ?>

--- a/delete_data.php
+++ b/delete_data.php
@@ -1,11 +1,5 @@
 <?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found"); 
-mysql_query("DELETE FROM member WHERE Mid='$_GET[mid]'"); 
+include 'conn.php';
+$mysqli->query("DELETE FROM member WHERE Mid='$_GET[mid]'"); 
 header ('location:ADview_member.php'); 
 ?>

--- a/memberEdit.php
+++ b/memberEdit.php
@@ -20,17 +20,10 @@
 				<!-- Column 1 start -->
 				
 				<?php
- $server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
+ include 'conn.php';
  
- 
- $data = mysql_query("SELECT * FROM member WHERE Mid='$_GET[mid]'");
- $r=mysql_fetch_array($data);
+ $data = $mysqli->query("SELECT * FROM member WHERE Mid='$_GET[mid]'");
+ $r=$data->fetch_array();
  
   
  echo "<h2>Edit Account</h2><hr> 

--- a/member_details.php
+++ b/member_details.php
@@ -29,14 +29,13 @@ if(!isset($_SESSION["sess_user"])){
 					<br><br>
 				
 <?php
-$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+include 'conn.php';
 	
 	$mid=$_SESSION['mid'];
 	
 
-$result = mysql_query("select * from member where Mid='".$mid."'");
-while($row = mysql_fetch_array($result))
+$result = $mysqli->query("select * from member where Mid='".$mid."'");
+while($row = $result->fetch_array())
 {
  
 ?>

--- a/member_login.php
+++ b/member_login.php
@@ -52,14 +52,25 @@ if(!empty($_POST['memusername']) && !empty($_POST['mempassword'])) {
 	$user=$_POST['memusername'];
 	$pass=$_POST['mempassword'];
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 
-	$query=mysql_query("SELECT * FROM member WHERE Mid='".$user."' AND Password='".$pass."'");
-	$numrows=mysql_num_rows($query);
+	$sql = sprintf("SELECT * FROM member WHERE Mid='%s' AND Password='%s'",
+		$mysqli->real_escape_string($user),
+		$mysqli->real_escape_string($pass));
+
+	$result=$mysqli->query($sql);
+	
+	if(!$result){
+		$message = 'Invalid query:'.$mysqli->error."<br>";
+		$message .= 'Whole query:'.$sql;
+		die($message);
+	}
+
+	$numrows = $result->num_rows;
+	
 	if($numrows!=0)
 	{
-	while($row=mysql_fetch_assoc($query))
+	while($row=$result->fetch_assoc())
 	{
 	$dbuser=$row['Name'];
 	$dbusername=$row['Mid'];
@@ -71,6 +82,7 @@ if(!empty($_POST['memusername']) && !empty($_POST['mempassword'])) {
 	session_start();
 	$_SESSION['sess_user']=$dbuser;
 	$_SESSION['mid']=$dbusername;
+	$_SESSION['level']="member";
 
 	/* Redirect browser */
 	header("Location: member.php");

--- a/member_reg.php
+++ b/member_reg.php
@@ -94,16 +94,15 @@ if(!empty($_POST['name']) && !empty($_POST['pass']) && !empty($_POST['mid']) && 
 	$address=$_POST['address'];
 	
 
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 
-	$query=mysql_query("SELECT * FROM member WHERE Mid='".$mid."'");
-	$numrows=mysql_num_rows($query);
+	$query=$mysqli->query("SELECT * FROM member WHERE Mid='".$mid."'");
+	$numrows=$query->num_rows;
 	if($numrows==0)
 	{
 		$sql="INSERT INTO member(Name,Mid,Email,Password,Branch,Year,ContactNo,Address) VALUES('$name','$mid','$email','$pass','$branch','$year','$contact','$address')";
 
-		$result=mysql_query($sql);
+		$result=$mysqli->query($sql);
 		if($result){
 	
 		echo "Account Successfully Created";

--- a/member_viewbook.php
+++ b/member_viewbook.php
@@ -19,15 +19,9 @@
 				<!-- Column 1 start -->
 				<br><br><br>
 				<?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
- mysql_select_db($database) or die ("Database Not Found");
+include 'conn.php';
  
- $data = mysql_query("SELECT * FROM book"); 
+ $data = $mysqli->query("SELECT * FROM book"); 
    echo "<table border='1' align='center'> 
  <th>Book ID</th> 
  <th>Book Name</th> 
@@ -40,7 +34,7 @@ $user = "root";
  <th>Action</th>";
  
  $no=1;
- while ($r=mysql_fetch_array($data))
+ while ($r=$data->fetch_array())
  { 
  echo "<tr>
  <td>$r[Bid]</td> 

--- a/memrequest_books.php
+++ b/memrequest_books.php
@@ -28,16 +28,14 @@ if(!isset($_SESSION["sess_user"])){
 				<br><br><br>
 				
 				<?php
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
-	
+	include 'conn.php';
 	
 	
 	
 	$mid=$_SESSION['mid'];
 	
-	$result=mysql_query("SELECT * FROM book where Bid='$_GET[bid]'");
-	while($row=mysql_fetch_assoc($result))
+	$result=$mysqli->query("SELECT * FROM book where Bid='$_GET[bid]'");
+	while($row=$result->fetch_assoc())
 	{
 	$available=$row['Availability'];
 	$bid=$row['Bid'];
@@ -46,8 +44,8 @@ if(!isset($_SESSION["sess_user"])){
 	}
 
 	$mid=$_SESSION['mid'];
-	$query=mysql_query("select * from member where Mid='$mid'");
-	while($row=mysql_fetch_assoc($query))
+	$query=$mysqli->query("select * from member where Mid='$mid'");
+	while($row=$query->fetch_assoc())
 	{
 		$mid=$row['Mid'];
 		$mname=$row['Name'];
@@ -55,8 +53,8 @@ if(!isset($_SESSION["sess_user"])){
 	}
 	//check book availability and no of books issued by member
 	
-	$query2=mysql_query("select * from member where Mid='$mid'");
-	while($row=mysql_fetch_assoc($query2))
+	$query2=$mysqli->query("select * from member where Mid='$mid'");
+	while($row=$query2->fetch_assoc())
 	{
 		$book1=$row['Book1'];
 		$book2=$row['Book2'];
@@ -84,7 +82,7 @@ if(!isset($_SESSION["sess_user"])){
 	
 	$sql="INSERT INTO requestbook(Mid,Name,Bid,Bname,requestdate) VALUES('$mid','$mname','$bid','$bname',now())";
    
-	$result=mysql_query($sql);
+	$result=$mysqli->query($sql);
 	if($result)
 	{
 		echo "Request sent";

--- a/memreturn_claim.php
+++ b/memreturn_claim.php
@@ -5,12 +5,11 @@ if(!isset($_SESSION["sess_user"])){
 } else {
 ?>
 <?php
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 	$issue_id=$_GET['Issue_id'];
 	$mid=$_SESSION['mid'];
-	$result=mysql_query("SELECT * FROM issuebook where Issue_id='$issue_id'");
-	while($row=mysql_fetch_assoc($result))
+	$result=$mysqli->query("SELECT * FROM issuebook where Issue_id='$issue_id'");
+	while($row=$result->fetch_assoc($result))
 	{
 	//insert into returnclaim table
      $issue_id=$row['Issue_id'];
@@ -20,7 +19,7 @@ if(!isset($_SESSION["sess_user"])){
 	 $bname=$row['Bname'];
 	 $validreturndate=$row['validreturndate'];
 	 }
-	 $result=mysql_query("Insert into claimreturn(Issue_id,Mid,Name,Bid,Bname,validreturndate,returnclaim_date)
+	 $result=$mysqli->query("Insert into claimreturn(Issue_id,Mid,Name,Bid,Bname,validreturndate,returnclaim_date)
 	 values('$issue_id','$mid','$name','$bid','$bname','$validreturndate',now())");
 
 	header ('location:member.php'); 

--- a/memreturnclaim_view.php
+++ b/memreturnclaim_view.php
@@ -6,12 +6,11 @@ if(!isset($_SESSION["sess_user"])){
 {
 ?>
 <?php
-	$con=mysql_connect('localhost','root','') or die(mysql_error());
-	mysql_select_db('library') or die("cannot select DB");
+	include 'conn.php';
 	
 	$mid=$_SESSION['mid'];
 	
-	$result=mysql_query("SELECT * FROM issuebook where Mid='$mid'");
+	$result=$mysqli_query("SELECT * FROM issuebook where Mid='$mid'");
 	
 	
 	
@@ -28,7 +27,7 @@ if(!isset($_SESSION["sess_user"])){
  <th>Action</th>";
  
  $no=1;
- while($r=mysql_fetch_assoc($result))
+ while($r=$result->fetch_assoc())
  { 
  echo "<tr>
  <td>$r[Issue_id]</td> 

--- a/update_book.php
+++ b/update_book.php
@@ -1,15 +1,10 @@
 //this file is meant to incorporate any changes made to book details so as to keep the database up to date
 <?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
 
- mysql_select_db($database) or die ("Database Not Found");  
-$query=mysql_query("UPDATE book SET Bid = '$_POST[bid]', Bname = '$_POST[bname]', Subject = '$_POST[Subject]', Author = '$_POST[author]', Availability = '$_POST[availability]'  WHERE Bid = '$_POST[bid]'"); 
+include 'conn.php';
+$query=$mysqli_query("UPDATE book SET Bid = '$_POST[bid]', Bname = '$_POST[bname]', Subject = '$_POST[Subject]', Author = '$_POST[author]', Availability = '$_POST[availability]'  WHERE Bid = '$_POST[bid]'"); 
 
 
 header ('location:ADview_book.php'); 
+
 ?>

--- a/update_member.php
+++ b/update_member.php
@@ -1,16 +1,11 @@
 /* this file will help students to update changes in  their personal information that might change like year the students are studying 
 in changes so changes will be made to existing account without creating a new account each year*/
 <?php 
-$server = "localhost"; 
-$user = "root";
- $password = "";
- $database = "library"; 
- mysql_connect($server,$user,$password)
- or die ("Connection Fails"); 
 
- mysql_select_db($database) or die ("Database Not Found");  
-$query=mysql_query("UPDATE member SET Name = '$_POST[Name]', Mid = '$_POST[mid]', Email = '$_POST[Email]',  Branch = '$_POST[Branch]', Year = '$_POST[Year]', ContactNo = '$_POST[ContactNo]', Address = '$_POST[Address]' WHERE Mid = '$_POST[mid]'"); 
+include 'conn.php';
+$query=$mysqli->query("UPDATE member SET Name = '$_POST[Name]', Mid = '$_POST[mid]', Email = '$_POST[Email]',  Branch = '$_POST[Branch]', Year = '$_POST[Year]', ContactNo = '$_POST[ContactNo]', Address = '$_POST[Address]' WHERE Mid = '$_POST[mid]'"); 
 
 
 header ('location:member_details.php'); 
+
 ?>


### PR DESCRIPTION
change mysql to mysqli with oo style because mysql was deprecated in PHP5.5.0 and it was removed in PHP 7.0.0
Each time when we Debug the code, php interpreter will warn that we should replace mysql_connect, mysql_query etc with methods packed in mysqli class. 
So I make this change to let the program can run in prior PHP interpreter. 

And I extract method of connecting mysql into conn.php, so it will be easer to modify when there are some changes happened with the database.